### PR TITLE
Duplicated DSTEMPLATE

### DIFF
--- a/sample-config/genConfig/Defaults_plugin_ciscocss.ini
+++ b/sample-config/genConfig/Defaults_plugin_ciscocss.ini
@@ -162,7 +162,7 @@
         view        = 	"""Hits: CiscoCSSapCntsvcHitsCs,
         Bytes: CiscoCSSapCntsvcBytesCs"""
     
-    [[CiscoCSS-ContentServiceAp]]
+    [[CiscoCSS-ServiceAp]]
         ds          =   "CiscoCSSapSvcConnectionsAp"
         view        =   "Connections: CiscoCSSapSvcConnectionsAp"
     


### PR DESCRIPTION
Hi,

There are two "CiscoCSS-ContentServiceAp" defined, resulting in a parse error while starting shinken arbiter with snmpbooster.

I think the first occurrence has the wrong name, so here is this fix.

Best regards,

N-Mi.
